### PR TITLE
Add Copyright Headers to generated files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,13 @@ jobs:
         echo "::set-output name=number::$([[ $(cat __zowe__version__ | grep zowe:) != "" ]] && (cat __zowe__version__ | grep zowe: | cut -d ':' -f 2) || echo 'CLI_v'$(npx zowe --version))"
         rm __zowe__version__
 
-    - name: Build Source
+    - name: Build Web Help
       id: build
-      run: npm run build:local -- ${{ github.event.inputs.zowe-version || steps.get-version.outputs.number }}
+      run: |
+        npm run build:local -- ${{ github.event.inputs.zowe-version || steps.get-version.outputs.number }}
+        npm install -g puppeteer-cli
+        export margin="0.4in"
+        puppeteer print ./generatedWebHelp/docs/all.html ./zowe.pdf --margin-top $margin --margin-right $margin --margin-bottom $margin --margin-left $margin --no-sandbox 
 
     - name: Archive Results
       id: upload
@@ -54,3 +58,4 @@ jobs:
         name: results
         path: |
           generatedWebHelp/
+          zowe.pdf

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,6 +19,6 @@ jobs:
     - run: |
         readarray -t all_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.all }}')"
         for file in ${all_files[@]}; do
-          [[ '${file}' == *.json ]] || (echo "Not a JSON file: ${file}" && exit 1)
+          [[ '${file}' == *.jsonc ]] || (echo "Not a JSON file: ${file}" && exit 1)
           [[ '${file}' == commandGroups/* ]] || [[ '${file}' == profiles/* ]] || (echo "Wrong location: ${file}" && exit 1)
         done

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ commandTree.json
 zowe.json
 tsconfig.tsbuildinfo
 package-lock.json
+.copyright

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contribution Guidelines
+## Sign all of your Git Commits
+
+Whenever you make a commit, it is required to be signed. If you do not, you will have to re-write the git history to get all commits signed before they can be merged, which can be quite a pain.
+
+Use the "-s" or "--signoff" flags to sign a commit.
+
+Example calls:
+* `git commit -s -m "Adding a test file to new_branch"`
+* `git commit --signoff -m "Adding a test file to new_branch"`
+
+Why? Sign-off is a line at the end of the commit message which certifies who is the author of the commit. Its main purpose is to improve tracking of who did what, especially with patches.
+
+Example commit in git history:
+
+```
+Add tests for the payment processor.
+
+Signed-off-by: Humpty Dumpty <humpty.dumpty@example.com>
+```
+
+What to do if you forget to sign off on a commit?
+
+To sign old commits: `git rebase --exec 'git commit --amend --no-edit --signoff' -i <commit-hash>`
+
+where commit hash is one before your first commit in history
+
+If you forget to signoff on a commit, you'll likely receive the following message:
+
+"Commit message must be signed off with your user name and email.
+To sign off your commit, add the -s flag to the git commit command."
+
+---
+
+## Contribution Instructions
+
+To contribute your Plug-in's information to this repository, reference the [README](./README.md) file and follow the instructions for [Installing Dependencies](./README.md#Installing) and [Contributing to the Web Help](./README.md#Using---Contributing-to-the-Web-Help).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-# Zowe Web Help Proof of Concept
+# Zowe Web Help Generator
+
+## About the Generator
 
 This proof of concept introduces some utilities that can be used to extract the command tree from the CLI and Plug-ins, store the relevant command groups for proprietary conformant plugins in a legal-approved way (without exposing proprietary code), and generate a web help with those plug-ins included on demand.
 
+---
+
 ## Installing
 
-To install the necessary components, run `npm install`.
+To install the necessary components, run `npm install`. For a minimal install, try `npm install --prod`.
+
+---
 
 ## Using - Contributing to the Web Help
 
 To add your conformant plug-in's commands, please perform the following steps:
 
-1. Ensure the plug-in that you would like to include is installed in Zowe CLI.
+1. Ensure the plug-in that you would like to contribute to the Web Help is installed in Zowe CLI. You can use `npx zowe plugins install <plugin name or path here>` if you do not have a globally installed Zowe CLI available.
 2. Copy the template file `zowe.template.json` in the `template` directory to `zowe.json` in the root of the project. This file is ignored by git. Customize this file to include the command group(s) of your plugin(s), and the name(s) of your profile(s), like the following:
 
         {
@@ -19,8 +25,14 @@ To add your conformant plug-in's commands, please perform the following steps:
         }
     *Note: No @zowe scoped plug-ins should be included in this repository, and the above is merely for demonstration purposes.*
 
-3. Run the `npm run contribute` command. This will retrieve the CLI command tree from Zowe CLI and all installed plug-ins, and extract the above command group(s) and profile(s) to the commandGroups and profiles directories.
-4. Commit the newly created files. Ensure the commit is signed off.
+3. (Optional) Include your Copyright. Add your copyright text to a file named `.copyright` in the root of the repository. This file will be ignored by git. If no copyright is supplied, the following default copyright will be added:
+
+        Copyright Contributors to the Zowe Project.
+
+4. Run the `npm run contribute` command. This will retrieve the CLI command tree from Zowe CLI and all installed plug-ins, and extract the above command group(s) and profile(s) to the commandGroups and profiles directories.
+5. Commit the newly created files. Ensure the commit is signed off.
+
+---
 
 ## Using - Generating the Web Help
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About the Generator
 
-This proof of concept introduces some utilities that can be used to extract the command tree from the CLI and Plug-ins, store the relevant command groups for proprietary conformant plugins in a legal-approved way (without exposing proprietary code), and generate a web help with those plug-ins included on demand.
+This repository introduces some utilities that can be used to extract the command tree from the CLI and Plug-ins, store the relevant command groups for third party conformant plugins in a legal-approved way (without exposing proprietary code), and generate a web help with those plug-ins included on demand.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
         "@types/node": "^16.11.1",
         "@zowe/cli": "6.36.0",
         "@zowe/imperative": "4.17.0",
-        "husky": "^7.0.4",
-        "ts-node": "10.3.0",
-        "typescript": "^4.4.4"
+        "husky": "^7.0.2",
+        "jsonc": "^2.0.0",
+        "ts-node": "^10.3.0",
+        "typescript": "^4.4.4",
+        "word-wrap": "^1.2.3"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.29.0",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -14,6 +14,7 @@ import { join } from "path";
 import { WebHelpGenerator, Imperative, ImperativeConfig, IHandlerResponseApi, HandlerResponse, CommandResponse } from "@zowe/imperative";
 import { getImperativeConfig } from "@zowe/cli";
 import { argv } from "process";
+import { jsonc as JSONC } from 'jsonc';
 
 (async() => {
     // Set up the environment and build the command tree
@@ -21,7 +22,7 @@ import { argv } from "process";
     const filePath = join(__dirname, "../", "commandTree.json");
     const localWebHelpDir = join(__dirname, "../", "generatedWebHelp");
     const fullCommandTree = readFileSync(filePath).toString();
-    const fullCommandTreeJson = JSON.parse(fullCommandTree).data;
+    const fullCommandTreeJson = JSONC.parse(fullCommandTree).data;
     const CLIImperativeConfig = getImperativeConfig();
     const fakeHandlerResponse: IHandlerResponseApi = new HandlerResponse(new CommandResponse({silent: true, responseFormat: "default"}));
 

--- a/scripts/merge.ts
+++ b/scripts/merge.ts
@@ -11,6 +11,7 @@
 
 import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import { jsonc as JSONC } from 'jsonc';
 
 (async() => {
     // Set up directories
@@ -24,13 +25,13 @@ import { join } from "path";
     const profilesUpdateDirectory = join(profilesDirectory, "update");
 
     // Read the file
-    const zoweTreeFileJSON = JSON.parse(readFileSync(zoweTreeFile).toString());
+    const zoweTreeFileJSON = JSONC.parse(readFileSync(zoweTreeFile).toString());
     const commandTree = zoweTreeFileJSON.data;
 
     // Add the missing command groups
     const commandGroupsFiles = readdirSync(commandGroupsDirectory);
     for (const file of commandGroupsFiles) {
-        const commandGroup = JSON.parse(readFileSync(join(commandGroupsDirectory, file)).toString());
+        const commandGroup = JSONC.parse(readFileSync(join(commandGroupsDirectory, file)).toString());
         let conflict = false;
         for (const compareGroup of commandTree.children) {
             if (compareGroup.name === commandGroup.name) { conflict = true; }
@@ -51,7 +52,7 @@ import { join } from "path";
                 if (child.name === "create") {
                     const files = readdirSync(profilesCreateDirectory);
                     for (const file of files) {
-                        const profile = JSON.parse(readFileSync(join(profilesCreateDirectory, file)).toString());
+                        const profile = JSONC.parse(readFileSync(join(profilesCreateDirectory, file)).toString());
                         let conflict = false;
                         for (const compareProfile of child.children) {
                             if (profile.name === compareProfile.name) { conflict = true; }
@@ -66,7 +67,7 @@ import { join } from "path";
                 } else if (child.name === "delete") {
                     const files = readdirSync(profilesDeleteDirectory);
                     for (const file of files) {
-                        const profile = JSON.parse(readFileSync(join(profilesDeleteDirectory, file)).toString());
+                        const profile = JSONC.parse(readFileSync(join(profilesDeleteDirectory, file)).toString());
                         let conflict = false;
                         for (const compareProfile of child.children) {
                             if (profile.name === compareProfile.name) { conflict = true; }
@@ -81,7 +82,7 @@ import { join } from "path";
                 } else if (child.name === "list") {
                     const files = readdirSync(profilesListDirectory);
                     for (const file of files) {
-                        const profile = JSON.parse(readFileSync(join(profilesListDirectory, file)).toString());
+                        const profile = JSONC.parse(readFileSync(join(profilesListDirectory, file)).toString());
                         let conflict = false;
                         for (const compareProfile of child.children) {
                             if (profile.name === compareProfile.name) { conflict = true; }
@@ -96,7 +97,7 @@ import { join } from "path";
                 } else if (child.name === "set-default") {
                     const files = readdirSync(profilesSetDefaultDirectory);
                     for (const file of files) {
-                        const profile = JSON.parse(readFileSync(join(profilesSetDefaultDirectory, file)).toString());
+                        const profile = JSONC.parse(readFileSync(join(profilesSetDefaultDirectory, file)).toString());
                         let conflict = false;
                         for (const compareProfile of child.children) {
                             if (profile.name === compareProfile.name) { conflict = true; }
@@ -111,7 +112,7 @@ import { join } from "path";
                 } else if (child.name === "update") {
                     const files = readdirSync(profilesUpdateDirectory);
                     for (const file of files) {
-                        const profile = JSON.parse(readFileSync(join(profilesUpdateDirectory, file)).toString());
+                        const profile = JSONC.parse(readFileSync(join(profilesUpdateDirectory, file)).toString());
                         let conflict = false;
                         for (const compareProfile of child.children) {
                             if (profile.name === compareProfile.name) { conflict = true; }
@@ -130,7 +131,7 @@ import { join } from "path";
 
     // Write data back to file
     zoweTreeFileJSON.data = commandTree;
-    const dataToWrite = JSON.stringify(zoweTreeFileJSON, (key, value) => (key !== "handler") ? value : "", 2);
+    const dataToWrite = JSONC.stringify(zoweTreeFileJSON, (key, value) => (key !== "handler") ? value : "", 2);
     writeFileSync(zoweTreeFile, dataToWrite);
 })().catch((error) => {
     console.log(error);

--- a/scripts/trim.ts
+++ b/scripts/trim.ts
@@ -11,19 +11,34 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
+import { jsonc as JSONC } from 'jsonc';
+const wrap = require("word-wrap");
 
 (async() => {
     // Read and parse the files
     const zoweFile = join(__dirname, "..", "zowe.json");
-    const zoweFileJSON = JSON.parse(readFileSync(zoweFile).toString());
+    const zoweFileJSON = JSONC.parse(readFileSync(zoweFile).toString());
     const zoweTreeFile = join(__dirname, "..", "commandTree.json");
-    const zoweTreeFileJSON = JSON.parse(readFileSync(zoweTreeFile).toString());
+    const zoweTreeFileJSON = JSONC.parse(readFileSync(zoweTreeFile).toString());
     const commandTree = zoweTreeFileJSON.data;
     const commandGroups = zoweFileJSON.commandGroups;
     const profiles = zoweFileJSON.profiles;
 
     let commandGroupsFound = 0;
     let profilesFound = 0;
+
+    // Prepare to add copyrights to files
+    let copyright: string;
+    const copyrightPath = join(__dirname, "../", ".copyright");
+    const wrapOptions = {indent: "// ", width: 77, trim: true};
+    if (existsSync(copyrightPath)) {
+        console.log("A copyright was found and will be used on all created files.");
+        copyright = wrap(readFileSync(copyrightPath).toString(), wrapOptions);
+    } else {
+        const zoweCopyright = "Copyright Contributors to the Zowe Project.";
+        console.log("No copyright file found, using default Zowe Copyright.");
+        copyright = wrap(zoweCopyright, wrapOptions);
+    }
 
     // Set up the directories, make sure they exist.
     const commandGroupsDirectory = join(__dirname, "..", "commandGroups");
@@ -46,8 +61,8 @@ import { join, resolve } from "path";
         for (const commandGroup of commandTree.children) {
             if (commandGroup.name === commandGroupSearching) {
                 // We found the command group. Save it, and break out of the inner for loop.
-                const commandGroupFilePath = join(__dirname, "..", "commandGroups", commandGroupSearching + ".json");
-                writeFileSync(commandGroupFilePath, JSON.stringify(commandGroup, (key, value) => (key !== "handler") ? value : "", 2));
+                const commandGroupFilePath = join(__dirname, "..", "commandGroups", commandGroupSearching + ".jsonc");
+                commonWriteFileSync(commandGroupFilePath, commandGroup, copyright);
                 console.log("Command Group " + commandGroupSearching + " was found and saved to: " + resolve(commandGroupFilePath));
                 commandGroupsFound++;
                 break;
@@ -67,12 +82,8 @@ import { join, resolve } from "path";
                         for (const profileType of child.children) {
                             if (profileType.name === profileSearching) {
                                 // We found the requested profile. Save it and break out of the inner loop.
-                                const profilesCreateFilePath = join(profilesCreateDirectory, profileSearching + ".json");
-                                writeFileSync(profilesCreateFilePath, JSON.stringify(
-                                    profileType,
-                                    (key, value) => (key !== "handler") ? value : "",
-                                    2
-                                ));
+                                const profilesCreateFilePath = join(profilesCreateDirectory, profileSearching + ".jsonc");
+                                commonWriteFileSync(profilesCreateFilePath, profileType, copyright);
                                 console.log("Profile " + profileSearching + " was found and saved to: " + resolve(profilesCreateFilePath));
                                 found++;
                                 break;
@@ -83,12 +94,8 @@ import { join, resolve } from "path";
                         for (const profileType of child.children) {
                             if (profileType.name === profileSearching) {
                                 // We found the requested profile. Save it and break out of the inner loop.
-                                const profilesDeleteFilePath = join(profilesDeleteDirectory, profileSearching + ".json");
-                                writeFileSync(profilesDeleteFilePath, JSON.stringify(
-                                    profileType,
-                                    (key, value) => (key !== "handler") ? value : "",
-                                    2
-                                ));
+                                const profilesDeleteFilePath = join(profilesDeleteDirectory, profileSearching + ".jsonc");
+                                commonWriteFileSync(profilesDeleteFilePath, profileType, copyright);
                                 console.log("Profile " + profileSearching + " was found and saved to: " + resolve(profilesDeleteFilePath));
                                 found++;
                                 break;
@@ -100,12 +107,8 @@ import { join, resolve } from "path";
                             if (profileType.name === profileSearching + "s") {
                                 // We found the requested profile. Save it and break out of the inner loop.
                                 // Yes, we add s, and that is intended.
-                                const profilesListFilePath = join(profilesListDirectory, profileSearching + ".json");
-                                writeFileSync(profilesListFilePath, JSON.stringify(
-                                    profileType,
-                                    (key, value) => (key !== "handler") ? value : "",
-                                    2
-                                ));
+                                const profilesListFilePath = join(profilesListDirectory, profileSearching + ".jsonc");
+                                commonWriteFileSync(profilesListFilePath, profileType, copyright);
                                 console.log("Profile " + profileSearching + " was found and saved to: " + resolve(profilesListFilePath));
                                 found++;
                                 break;
@@ -116,12 +119,8 @@ import { join, resolve } from "path";
                         for (const profileType of child.children) {
                             if (profileType.name === profileSearching) {
                                 // We found the requested profile. Save it and break out of the inner loop.
-                                const profilesSetDefaultFilePath = join(profilesSetDefaultDirectory, profileSearching + ".json");
-                                writeFileSync(profilesSetDefaultFilePath, JSON.stringify(
-                                    profileType,
-                                    (key, value) => (key !== "handler") ? value : "",
-                                    2
-                                ));
+                                const profilesSetDefaultFilePath = join(profilesSetDefaultDirectory, profileSearching + ".jsonc");
+                                commonWriteFileSync(profilesSetDefaultFilePath, profileType, copyright);
                                 console.log("Profile " + profileSearching + " was found and saved to: " + resolve(profilesSetDefaultFilePath));
                                 found++;
                                 break;
@@ -132,12 +131,8 @@ import { join, resolve } from "path";
                         for (const profileType of child.children) {
                             if (profileType.name === profileSearching) {
                                 // We found the requested profile. Save it and break out of the inner loop.
-                                const profilesUpdateFilePath = join(profilesUpdateDirectory, profileSearching + ".json");
-                                writeFileSync(profilesUpdateFilePath, JSON.stringify(
-                                    profileType,
-                                    (key, value) => (key !== "handler") ? value : "",
-                                    2
-                                ));
+                                const profilesUpdateFilePath = join(profilesUpdateDirectory, profileSearching + ".jsonc");
+                                commonWriteFileSync(profilesUpdateFilePath, profileType, copyright);
                                 console.log("Profile " + profileSearching + " was found and saved to: " + resolve(profilesUpdateFilePath));
                                 found++;
                                 break;
@@ -157,3 +152,12 @@ import { join, resolve } from "path";
     console.log(error);
     process.exit(1);
 });
+
+function commonWriteFileSync(path: string, json: any, copyright: string) {
+    const data = copyright + "\n" + JSONC.stringify(
+        json,
+        (key, value) => (key !== "handler") ? value : "",
+        2
+    );
+    writeFileSync(path, data);
+}


### PR DESCRIPTION
Adds copyright headers to all files trimmed out of the command tree that remain in our repository.
Also adds contribution instructions and documents these changes.
Also adds PDF generation of the web help.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>